### PR TITLE
fix: remove k8s version from node group config

### DIFF
--- a/Infra/EKS/main.tf
+++ b/Infra/EKS/main.tf
@@ -200,7 +200,6 @@ resource "aws_eks_node_group" "eks_nodes" {
   ami_type        = var.ami_type
   node_role_arn   = aws_iam_role.eks_node_role.arn
   subnet_ids      = var.subnet_ids 
-  version         =  var.k8s_version
   scaling_config {
     desired_size = var.desired_capacity
     max_size     = var.max_capacity

--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -32,12 +32,12 @@ module "eks" {
 
 
 # create s3 bucket to store terraform state file.
-resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-state-techn"
+# resource "aws_s3_bucket" "bucket" {
+#   bucket = "tf-state-techn"
 
-  tags = {
-    Name        = "tf_bucket"
-    Environment = var.environment
-  }
-}
+#   tags = {
+#     Name        = "tf_bucket"
+#     Environment = var.environment
+#   }
+# }
 


### PR DESCRIPTION
remove k8s version from node group config since a launch template is provided instead. The s3 bucket created as terraform backend was also commented out.